### PR TITLE
feat: add pluggable AI engine framework

### DIFF
--- a/apps/backend/src/ai-engine/ai-api-engine.base.ts
+++ b/apps/backend/src/ai-engine/ai-api-engine.base.ts
@@ -1,6 +1,7 @@
 export interface ChatPayload {
   prompt: string;
   apiKey?: string;
+  // Zukünftige Optionen wie temperature, model, etc. können hier hinzugefügt werden
 }
 
 export interface ChatResponse {

--- a/apps/backend/src/ai-engine/openai.engine.ts
+++ b/apps/backend/src/ai-engine/openai.engine.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AiApiEngine, ChatPayload, ChatResponse } from './ai-api-engine.base';
 
 @Injectable()
@@ -8,9 +8,11 @@ export class OpenAiEngine extends AiApiEngine {
   async sendMessage(payload: ChatPayload): Promise<ChatResponse> {
     // HINWEIS: Dies ist eine Platzhalter-Implementierung.
     // Hier würde die eigentliche Logik zur Kommunikation mit der OpenAI-API stehen.
+    // z.B. mit dem 'openai' npm-Paket.
     if (!payload.apiKey) {
-      return { content: 'Error: OpenAI API key is missing.' };
+      return { content: 'Fehler: OpenAI API-Schlüssel fehlt.' };
     }
+    await Promise.resolve();
     return {
       content: `(Platzhalter) OpenAI würde jetzt die Frage "${payload.prompt}" beantworten.`,
     };

--- a/apps/backend/src/chat.controller.ts
+++ b/apps/backend/src/chat.controller.ts
@@ -1,16 +1,20 @@
-import { Body, Controller, Param, Post } from '@nestjs/common';
+import { Controller, Post, Body } from '@nestjs/common';
 import { ChatService } from './chat.service';
-import { ChatPayload, ChatResponse } from './ai-engine/ai-api-engine.base';
 
-@Controller('chat')
+// DTO für eingehende Anfragen
+class ChatRequestDto {
+  provider: string;
+  prompt: string;
+  apiKey?: string;
+}
+
+@Controller('api/chat')
 export class ChatController {
   constructor(private readonly chatService: ChatService) {}
 
-  @Post(':provider')
-  async sendMessage(
-    @Param('provider') provider: string,
-    @Body() payload: ChatPayload,
-  ): Promise<ChatResponse> {
-    return this.chatService.sendMessage(provider, payload);
+  @Post()
+  sendMessage(@Body() requestDto: ChatRequestDto) {
+    const { provider, ...payload } = requestDto;
+    return this.chatService.handleMessage(provider, payload);
   }
 }

--- a/apps/backend/src/chat.module.ts
+++ b/apps/backend/src/chat.module.ts
@@ -3,21 +3,10 @@ import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
 import { DummyEngine } from './ai-engine/dummy.engine';
 import { OpenAiEngine } from './ai-engine/openai.engine';
-import { AiApiEngine } from './ai-engine/ai-api-engine.base';
-
-const engineProviders = [DummyEngine, OpenAiEngine];
 
 @Module({
-  providers: [
-    ...engineProviders,
-    {
-      provide: 'AI_ENGINES',
-      useFactory: (...engines: AiApiEngine[]) => engines,
-      inject: engineProviders,
-    },
-    ChatService,
-  ],
   controllers: [ChatController],
-  exports: [ChatService],
+  // Registriere alle Engines hier als Provider
+  providers: [ChatService, DummyEngine, OpenAiEngine],
 })
 export class ChatModule {}

--- a/apps/backend/src/chat.service.ts
+++ b/apps/backend/src/chat.service.ts
@@ -1,18 +1,38 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { AiApiEngine, ChatPayload, ChatResponse } from './ai-engine/ai-api-engine.base';
+import { Injectable, NotFoundException, OnModuleInit } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import {
+  AiApiEngine,
+  ChatPayload,
+  ChatResponse,
+} from './ai-engine/ai-api-engine.base';
+import { DummyEngine } from './ai-engine/dummy.engine';
+import { OpenAiEngine } from './ai-engine/openai.engine';
 
 @Injectable()
-export class ChatService {
-  private readonly engines = new Map<string, AiApiEngine>();
+export class ChatService implements OnModuleInit {
+  private engines: Map<string, AiApiEngine> = new Map();
 
-  constructor(@Inject('AI_ENGINES') engines: AiApiEngine[]) {
-    engines.forEach((engine) => this.engines.set(engine.provider, engine));
+  // ModuleRef wird verwendet, um alle Instanzen von AiApiEngine zu finden
+  constructor(private moduleRef: ModuleRef) {}
+
+  onModuleInit() {
+    // Finde alle Provider, die von AiApiEngine erben
+    const engineImplementations = [DummyEngine, OpenAiEngine];
+    engineImplementations.forEach((engineClass) => {
+      const engineInstance = this.moduleRef.get(engineClass, { strict: false });
+      this.engines.set(engineInstance.provider, engineInstance);
+    });
   }
 
-  async sendMessage(provider: string, payload: ChatPayload): Promise<ChatResponse> {
+  async handleMessage(
+    provider: string,
+    payload: ChatPayload,
+  ): Promise<ChatResponse> {
     const engine = this.engines.get(provider);
     if (!engine) {
-      throw new NotFoundException(`Fehler: Provider '${provider}' nicht unterstützt.`);
+      throw new NotFoundException(
+        `Provider '${provider}' wird nicht unterstützt.`,
+      );
     }
     return engine.sendMessage(payload);
   }


### PR DESCRIPTION
## Summary
- add base interfaces and abstract AI engine definition
- wire up ChatService to dynamically register dummy and OpenAI engines
- expose unified `/api/chat` endpoint selecting engine via request body

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c9c5696c833380cfbc1288bbf4ed