### PR TITLE
feat(frontend): add sidebar layout and LM Studio option

### DIFF
--- a/apps/frontend/src/app/app.component.html
+++ b/apps/frontend/src/app/app.component.html
@@ -1,65 +1,97 @@
-<div class="flex flex-col h-screen bg-gray-100 font-sans">
-  <!-- Header -->
-  <header class="bg-white shadow-md p-4 z-10">
-    <h1 class="text-xl font-bold text-gray-800">Chateroo AI Wrapper</h1>
-  </header>
-
-  <!-- Nachrichtenbereich -->
-  <div class="flex-1 p-4 overflow-y-auto space-y-4">
-    <div
-      *ngFor="let msg of messages"
-      [ngClass]="{
-        'self-end bg-blue-100 text-right': msg.sender === 'user',
-        'self-start bg-gray-200 text-left': msg.sender === 'ai'
-      }"
-      class="max-w-xs w-fit rounded-lg p-3"
-    >
-      <ng-container *ngIf="msg.isLoading; else msgText">
-        <div class="flex items-center space-x-2">
-          <span class="w-2 h-2 bg-gray-400 rounded-full animate-pulse"></span>
-          <span class="w-2 h-2 bg-gray-400 rounded-full animate-pulse delay-75"></span>
-          <span class="w-2 h-2 bg-gray-400 rounded-full animate-pulse delay-150"></span>
-        </div>
-      </ng-container>
-      <ng-template #msgText>{{ msg.text }}</ng-template>
+<div class="flex h-screen bg-gray-200 font-sans">
+  <!-- Sidebar -->
+  <aside class="w-64 bg-gray-800 text-white flex flex-col">
+    <div class="p-4 border-b border-gray-700">
+      <h1 class="text-xl font-bold">Chateroo</h1>
     </div>
-  </div>
+    <nav class="flex-1 p-2 space-y-2">
+      <a href="#" class="flex items-center px-4 py-2 rounded-md bg-gray-700 text-white">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 mr-3">
+          <path
+            fill-rule="evenodd"
+            d="M4.804 21.644A6.707 6.707 0 0 1 4.5 21.75a.75.75 0 0 1-.743-.898l.68-4.223a.75.75 0 0 1 .224-.492l.001-.002a18.202 18.202 0 0 1 1.83-2.144a15.662 15.662 0 0 0 1.108-1.367c.228-.33.43-1.013.43-1.429V7.5a6.75 6.75 0 0 1 6.75-6.75h.5c.394 0 .783.023 1.168.068a.75.75 0 0 1 .718.826l-.347 4.165a.75.75 0 0 1-.678.649c-.417.034-.833.052-1.251.052h-.5a2.25 2.25 0 0 0-2.25 2.25v2.25a.75.75 0 0 1-1.5 0v-2.25a3.75 3.75 0 0 1 3.75-3.75h.5a15.023 15.023 0 0 1 2.367.241l.24-.24a.75.75 0 0 1 1.06 0l1.83 1.83a.75.75 0 0 1 0 1.06l-2.052 2.052a.75.75 0 0 1-.521.22h-3.37a3.75 3.75 0 0 0-3.75 3.75v1.5a.75.75 0 0 1-1.5 0v-1.5a2.25 2.25 0 0 1 2.25-2.25h1.5a.75.75 0 0 1 0 1.5h-1.5a.75.75 0 0 0-.75.75v3.196a17.398 17.398 0 0 1-2.02 2.446l-.002.002a.75.75 0 0 1-.493.224l-4.223.68a.75.75 0 0 1-.898-.743 6.707 6.707 0 0 1 .144-.306Z"
+            clip-rule="evenodd"
+          />
+          <path d="M16.742 4.127a.75.75 0 0 1 .228 1.034l-2.083 3.644a.75.75 0 0 1-1.262-.72l2.083-3.644a.75.75 0 0 1 1.034-.228Z" />
+        </svg>
+        <span>Chat</span>
+      </a>
+      <a
+        href="#"
+        class="flex items-center px-4 py-2 rounded-md text-gray-400 hover:bg-gray-700 hover:text-white"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 mr-3">
+          <path
+            fill-rule="evenodd"
+            d="M12 3.75a.75.75 0 0 1 .75.75v6.75h6.75a.75.75 0 0 1 0 1.5h-6.75v6.75a.75.75 0 0 1-1.5 0v-6.75H4.5a.75.75 0 0 1 0-1.5h6.75V4.5a.75.75 0 0 1 .75-.75Z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <span>Projekte (bald)</span>
+      </a>
+    </nav>
+  </aside>
 
-  <!-- Eingabebereich -->
-  <div class="p-4 bg-white border-t border-gray-200">
-    <form
-      [formGroup]="chatForm"
-      (ngSubmit)="sendMessage()"
-      class="flex items-center space-x-4"
-    >
-      <select
-        formControlName="provider"
-        class="p-2 border rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+  <!-- Main content -->
+  <div class="flex flex-col flex-1">
+    <!-- Nachrichtenbereich -->
+    <div class="flex-1 p-4 overflow-y-auto space-y-4">
+      <div
+        *ngFor="let msg of messages"
+        [ngClass]="{
+          'self-end bg-blue-100 text-right': msg.sender === 'user',
+          'self-start bg-gray-200 text-left': msg.sender === 'ai'
+        }"
+        class="max-w-xs w-fit rounded-lg p-3"
       >
-        <option value="dummy">Dummy</option>
-        <option value="openai">OpenAI</option>
-      </select>
-      <input
-        formControlName="apiKey"
-        *ngIf="chatForm.get('provider')?.value === 'openai'"
-        type="password"
-        placeholder="OpenAI API Key..."
-        class="p-2 border rounded-md flex-shrink w-1/4 focus:outline-none focus:ring-2 focus:ring-blue-500"
-      />
-      <input
-        formControlName="prompt"
-        type="text"
-        placeholder="Schreibe deine Nachricht..."
-        class="flex-1 p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-      />
-      <button
-        type="submit"
-        [disabled]="chatForm.invalid || isLoading"
-        class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 disabled:bg-blue-300 disabled:cursor-not-allowed transition-colors"
+        <ng-container *ngIf="msg.isLoading; else msgText">
+          <div class="flex items-center space-x-2">
+            <span class="w-2 h-2 bg-gray-400 rounded-full animate-pulse"></span>
+            <span class="w-2 h-2 bg-gray-400 rounded-full animate-pulse delay-75"></span>
+            <span class="w-2 h-2 bg-gray-400 rounded-full animate-pulse delay-150"></span>
+          </div>
+        </ng-container>
+        <ng-template #msgText>{{ msg.text }}</ng-template>
+      </div>
+    </div>
+
+    <!-- Eingabebereich -->
+    <div class="p-4 bg-white border-t border-gray-200">
+      <form
+        [formGroup]="chatForm"
+        (ngSubmit)="sendMessage()"
+        class="flex items-center space-x-4"
       >
-        Senden
-      </button>
-    </form>
+        <select
+          formControlName="provider"
+          class="p-2 border rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="dummy">Dummy</option>
+          <option value="lm-studio">LM Studio (Lokal)</option>
+          <option value="openai">OpenAI</option>
+        </select>
+        <input
+          formControlName="apiKey"
+          *ngIf="chatForm.get('provider')?.value === 'openai'"
+          type="password"
+          placeholder="OpenAI API Key..."
+          class="p-2 border rounded-md flex-shrink w-1/4 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <input
+          formControlName="prompt"
+          type="text"
+          placeholder="Schreibe deine Nachricht..."
+          class="flex-1 p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button
+          type="submit"
+          [disabled]="chatForm.invalid || isLoading"
+          class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 disabled:bg-blue-300 disabled:cursor-not-allowed transition-colors"
+        >
+          Senden
+        </button>
+      </form>
+    </div>
   </div>
 </div>
 

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { ChatService, SendMessagePayload } from './core/services/chat.service';
+import { ChatService } from './core/services/chat.service';
 import { ChatMessage } from './models/chat.model';
 
 @Component({
@@ -19,7 +19,7 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
     this.chatForm = this.fb.group({
-      provider: ['dummy', Validators.required],
+      provider: ['lm-studio', Validators.required],
       prompt: ['', Validators.required],
       apiKey: [''],
     });
@@ -27,7 +27,7 @@ export class AppComponent implements OnInit {
     // Begrüßungsnachricht
     this.messages.push({
       sender: 'ai',
-      text: 'Hallo! Wie kann ich dir heute helfen?',
+      text: 'Hallo! Wähle einen Provider und stelle eine Frage.',
     });
   }
 
@@ -42,13 +42,7 @@ export class AppComponent implements OnInit {
     this.isLoading = true;
     this.chatForm.get('prompt')?.disable();
 
-    const payload: SendMessagePayload = {
-      provider: formValue.provider,
-      prompt: formValue.prompt,
-      apiKey: formValue.apiKey,
-    };
-
-    this.chatService.sendMessage(payload).subscribe({
+    this.chatService.sendMessage(formValue).subscribe({
       next: (res) => {
         // Ersetze die Lade-Nachricht mit der echten Antwort
         const lastMessageIndex = this.messages.length - 1;


### PR DESCRIPTION
## Summary
- build new sidebar-based layout for chat UI
- add LM Studio provider option and default selection

## Testing
- `npm test --workspace=frontend -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless cannot start as root without --no-sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_6893cee672cc83339f89e74d330c28c3