### PR TITLE
Fix Enter key for chat and connect LM Studio

### DIFF
--- a/apps/frontend/src/app/app.component.html
+++ b/apps/frontend/src/app/app.component.html
@@ -65,7 +65,7 @@
 
           <input formControlName="apiKey" *ngIf="chatForm.get('provider')?.value === 'openai'" type="password" placeholder="OpenAI API Key..." class="p-2 border rounded-md flex-shrink w-1/4 focus:outline-none focus:ring-2 focus:ring-blue-500">
 
-          <input formControlName="prompt" type="text" placeholder="Type your message..." class="flex-1 p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <input formControlName="prompt" type="text" placeholder="Type your message..." class="flex-1 p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" (keydown.enter)="sendMessage(); $event.preventDefault()">
 
           <button type="submit" [disabled]="chatForm.invalid || isLoading" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 disabled:bg-blue-300 disabled:cursor-not-allowed transition-colors">
             Send

--- a/apps/frontend/src/app/core/services/chat.service.ts
+++ b/apps/frontend/src/app/core/services/chat.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 export interface SendMessagePayload {
   provider: string;
@@ -19,6 +19,22 @@ export class ChatService {
   public constructor(private http: HttpClient) {}
 
   public sendMessage(payload: SendMessagePayload): Observable<ChatApiResponse> {
+    if (payload.provider === 'lm-studio') {
+      const body = {
+        model: 'local-model',
+        messages: [{ role: 'user', content: payload.prompt }],
+        temperature: 0.7,
+      };
+
+      return this.http
+        .post<any>('http://localhost:1234/v1/chat/completions', body, {
+          headers: { 'Content-Type': 'application/json' },
+        })
+        .pipe(
+          map((res) => ({ content: res.choices?.[0]?.message?.content || '' })),
+        );
+    }
+
     return this.http.post<ChatApiResponse>(this.apiUrl, payload);
   }
 }


### PR DESCRIPTION
## Summary
- Send chat messages when pressing Enter
- Directly call LM Studio API for local conversations

## Testing
- `npm test --workspace=backend`
- `npm test --workspace=frontend -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68947e9d875c8333a30b12b9a49b64c0