### PR TITLE
refactor(frontend): route LM Studio requests through backend

### DIFF
--- a/apps/frontend/src/app/core/services/chat.service.ts
+++ b/apps/frontend/src/app/core/services/chat.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, map } from 'rxjs';
+import { Observable } from 'rxjs';
 
 export interface SendMessagePayload {
   provider: string;
@@ -19,32 +19,11 @@ export class ChatService {
   public constructor(private http: HttpClient) {}
 
   /**
-   * Sends a message using either a local model or an external provider.
-   *
-   * This function checks the provider specified in the payload and constructs
-   * the request body accordingly. If the provider is 'lm-studio', it sends the
-   * request to a local server with a fixed configuration. For other providers,
-   * it posts the payload directly to the configured API URL.
+   * Sends a message to the backend which forwards it to the selected provider.
    *
    * @param payload - The message payload containing details like prompt and provider.
    */
   public sendMessage(payload: SendMessagePayload): Observable<ChatApiResponse> {
-    if (payload.provider === 'lm-studio') {
-      const body = {
-        model: 'local-model',
-        messages: [{ role: 'user', content: payload.prompt }],
-        temperature: 0.7,
-      };
-
-      return this.http
-        .post<any>('http://localhost:1234/v1/chat/completions', body, {
-          headers: { 'Content-Type': 'application/json' },
-        })
-        .pipe(
-          map((res) => ({ content: res.choices?.[0]?.message?.content || '' })),
-        );
-    }
-
     return this.http.post<ChatApiResponse>(this.apiUrl, payload);
   }
 }


### PR DESCRIPTION
### **User description**
## Summary
- send all chat requests through backend for provider handling

## Testing
- `npm --workspace=backend test`
- `npm --workspace=frontend test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68948615502c8333b535dae3b36f6cc1


___

### **Description**
- Refactored `ChatService` to ensure all chat requests are routed through the backend.
- Removed local model handling for the 'lm-studio' provider to streamline the request process.
- Simplified the `sendMessage` method for better maintainability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat.service.ts</strong><dd><code>Refactor ChatService to Route All Requests Through Backend</code></dd></summary>
<hr>

apps/frontend/src/app/core/services/chat.service.ts
<li>Removed local model handling for 'lm-studio' provider.<br> <li> Updated <code>sendMessage</code> method to send all requests through the backend.<br> <li> Simplified request construction by removing unnecessary conditions.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/28/files#diff-96ba90c433b3cafd9392743ca8f6151172af6d0a01649b18f6e288e0af7fa2b6">+2/-23</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

