### PR TITLE
Fix Enter key not sending chat messages

### DIFF
--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -42,7 +42,19 @@ export class AppComponent implements OnInit {
     // Initialize the chat form
     this.chatForm = this.fb.group({
       provider: ['lm-studio', Validators.required],
+      apiKey: [''],
       prompt: ['', Validators.required],
+    });
+
+    // Toggle API key requirement based on selected provider
+    this.chatForm.get('provider')?.valueChanges.subscribe((provider) => {
+      const apiKeyControl = this.chatForm.get('apiKey');
+      if (provider === 'openai') {
+        apiKeyControl?.setValidators([Validators.required]);
+      } else {
+        apiKeyControl?.clearValidators();
+      }
+      apiKeyControl?.updateValueAndValidity();
     });
 
     // Initialize the settings form with loaded data
@@ -87,7 +99,7 @@ export class AppComponent implements OnInit {
     this.addUserAndLoadingMessages(formValue.prompt);
     this.togglePrompt(false);
 
-    const apiKey = this.settingsService.getApiKey(formValue.provider);
+    const apiKey = formValue.apiKey || this.settingsService.getApiKey(formValue.provider);
     const payload: SendMessagePayload = {
       provider: formValue.provider,
       prompt: formValue.prompt,


### PR DESCRIPTION
## Summary
- ensure chat form includes API key control and toggles validation when switching providers
- use API key from form or stored settings when sending a message

## Testing
- `npm test --workspace=backend`
- `npm test --workspace=frontend` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable)*

------
https://chatgpt.com/codex/tasks/task_e_6894854d84808333b3c08aeb9816dac7

## Summary by Sourcery

Add API key control to chat form with dynamic validation and ensure messages use the provided key when sending

Bug Fixes:
- Use API key from chat form or stored settings when sending messages

Enhancements:
- Add apiKey field to chat form
- Toggle API key validation based on selected provider