### PR TITLE
fix: rely on form submit for chat

### DIFF
--- a/apps/frontend/src/app/app.component.html
+++ b/apps/frontend/src/app/app.component.html
@@ -70,7 +70,7 @@
 
           <input formControlName="apiKey" *ngIf="requiresApiKey(chatForm.get('provider')?.value)" type="password" placeholder="API Key..." class="p-2 border rounded-md flex-shrink w-1/4 focus:outline-none focus:ring-2 focus:ring-blue-500">
 
-          <input formControlName="prompt" type="text" placeholder="Type your message..." class="flex-1 p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" (keydown.enter)="sendMessage(); $event.preventDefault()">
+          <input formControlName="prompt" type="text" placeholder="Type your message..." class="flex-1 p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
 
           <button type="submit" [disabled]="chatForm.invalid || isLoading" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 disabled:bg-blue-300 disabled:cursor-not-allowed transition-colors">
             Send


### PR DESCRIPTION
## Summary
- remove redundant keydown handler from chat input so form submission relies on ngSubmit

## Testing
- `CHROME_BIN=/usr/bin/chromium-browser npm test --workspace=frontend -- --watch=false --browsers=ChromeHeadless` (fails: ChromeHeadless requires chromium snap)


------
https://chatgpt.com/codex/tasks/task_e_689490fca2a88333aec9cabd44e91ee5