### PR TITLE
fix: keep chat input fixed and scroll messages

### DIFF
--- a/apps/frontend/src/app/core/components/chat/chat.component.ts
+++ b/apps/frontend/src/app/core/components/chat/chat.component.ts
@@ -13,6 +13,9 @@ import DOMPurify from 'dompurify';
   standalone: true,
   imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './chat.component.html',
+  host: {
+    class: 'flex flex-col flex-1'
+  }
 })
 export class ChatComponent implements OnInit {
   public chatForm!: FormGroup;


### PR DESCRIPTION
### **User description**
## Summary
- ensure chat component fills available height so message list scrolls and input bar stays fixed

## Testing
- `npm test` *(fails: Cannot find module 'tauri-plugin-store-api')*

------
https://chatgpt.com/codex/tasks/task_e_68b41a389ea08333a6ce86eb10750c9e


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Improved the layout of the chat component to ensure the input bar remains fixed while messages scroll.
- Added a host property to the `ChatComponent` to apply necessary CSS classes for layout.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat.component.ts</strong><dd><code>Fix chat input positioning and layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/core/components/chat/chat.component.ts
<li>Added a host property to the <code>ChatComponent</code>.<br> <li> Set the class to 'flex flex-col flex-1' to ensure proper layout.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/51/files#diff-c332569acce84e4c30bce961d2db32465729c68a63cdcc09e2fce57bcf2a7012">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

