### PR TITLE
feat(frontend): auto-scroll chat to latest message

### DIFF
--- a/apps/frontend/src/app/core/components/chat/chat.component.html
+++ b/apps/frontend/src/app/core/components/chat/chat.component.html
@@ -1,4 +1,4 @@
-<div class="flex-1 p-6 overflow-y-auto space-y-4">
+<div #chatContainer class="flex-1 p-6 overflow-y-auto space-y-4">
   <div *ngFor="let message of messages" class="flex" [ngClass]="{'justify-end': message.sender === 'user', 'justify-start': message.sender === 'ai'}">
     <div class="max-w-2xl p-3 rounded-lg shadow-md" [ngClass]="{'bg-blue-500 text-white': message.sender === 'user', 'bg-white text-gray-800': message.sender === 'ai'}">
       <div *ngIf="!message.isLoading" class="markdown-content" [innerHTML]="renderMarkdown(message.text)"></div>

--- a/apps/frontend/src/app/core/components/chat/chat.component.ts
+++ b/apps/frontend/src/app/core/components/chat/chat.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewChecked, ElementRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 
@@ -15,10 +15,12 @@ import DOMPurify from 'dompurify';
   templateUrl: './chat.component.html',
   host: { class: 'flex flex-col flex-1 min-h-0' },
 })
-export class ChatComponent implements OnInit {
+export class ChatComponent implements OnInit, AfterViewChecked {
   public chatForm!: FormGroup;
   public messages: ChatMessage[] = [];
   public isLoading = false;
+
+  @ViewChild('chatContainer') private chatContainer!: ElementRef<HTMLDivElement>;
 
   private readonly providersWithApiKey = [
     'openai',
@@ -84,6 +86,10 @@ export class ChatComponent implements OnInit {
     });
   }
 
+  public ngAfterViewChecked(): void {
+    this.scrollToBottom();
+  }
+
   /**
    * Converts markdown text to sanitized HTML.
    * @param text The raw markdown text from the LLM.
@@ -126,6 +132,13 @@ export class ChatComponent implements OnInit {
     this.messages[lastIndex] = { sender: 'ai', text: errorMessage };
     this.isLoading = false;
     this.togglePrompt(true);
+  }
+
+  private scrollToBottom(): void {
+    const container = this.chatContainer?.nativeElement;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
   }
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- auto-scroll chat container to the latest message on every update

## Testing
- `npm test -- --watch=false` (fails: Cannot find module 'tauri-plugin-store-api')

------
https://chatgpt.com/codex/tasks/task_e_68b4270f163c8333a35ec8f27399c07b


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Implemented auto-scrolling feature for the chat component to ensure the latest messages are visible.
- Utilized Angular's `AfterViewChecked` lifecycle hook to trigger scrolling after view updates.
- Added a new method `scrollToBottom` to manage the scrolling behavior.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat.component.html</strong><dd><code>Update chat component HTML for auto-scrolling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/core/components/chat/chat.component.html
<li>Added a reference to the chat container for scrolling.<br> <li> Updated the structure to facilitate auto-scrolling.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/52/files#diff-d967e9adb1f135cdd1fb1cbcfb12d8c3f2cc5e59f0d680e2e06b510218b08e0e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.component.ts</strong><dd><code>Enhance chat component with auto-scroll functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/core/components/chat/chat.component.ts
<li>Implemented <code>AfterViewChecked</code> lifecycle hook for scrolling.<br> <li> Added <code>scrollToBottom</code> method to handle auto-scrolling.<br> <li> Introduced <code>@ViewChild</code> to access the chat container.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/52/files#diff-c332569acce84e4c30bce961d2db32465729c68a63cdcc09e2fce57bcf2a7012">+15/-2</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Chat now auto-scrolls to the newest message after updates, so you always see the latest part of the conversation without manual scrolling.
  * Works when sending or receiving messages, providing a smoother experience during active chats and long threads.
  * Reduces the need to scroll back down after new content loads, improving readability and continuity in ongoing conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->