### PR TITLE
feat: integrate OpenRouter API engine

### DIFF
--- a/apps/backend/src/ai-engine/ai-api-engine.base.ts
+++ b/apps/backend/src/ai-engine/ai-api-engine.base.ts
@@ -1,7 +1,8 @@
 export interface ChatPayload {
   prompt: string;
   apiKey?: string;
-  // Zukünftige Optionen wie temperature, model, etc. können hier hinzugefügt werden
+  model?: string;
+  // Zukünftige Optionen wie temperature, etc. können hier hinzugefügt werden
 }
 
 export interface ChatResponse {

--- a/apps/backend/src/ai-engine/new-engines.spec.ts
+++ b/apps/backend/src/ai-engine/new-engines.spec.ts
@@ -5,6 +5,7 @@ import { GeminiEngine } from './gemini.engine';
 import { PerplexityEngine } from './perplexity.engine';
 import { GrokEngine } from './grok.engine';
 import { DeepseekEngine } from './deepseek.engine';
+import { OpenRouterEngine } from './openrouter.engine';
 
 describe.each([
   {
@@ -36,6 +37,12 @@ describe.each([
     Engine: DeepseekEngine,
     url: 'https://api.deepseek.com/chat/completions',
     model: 'deepseek-chat',
+  },
+  {
+    name: 'OpenRouter',
+    Engine: OpenRouterEngine,
+    url: 'https://openrouter.ai/api/v1/chat/completions',
+    model: 'openai/gpt-4o-mini',
   },
 ])('$nameEngine', ({ name, Engine, url, model }) => {
   let engine: InstanceType<typeof Engine>;

--- a/apps/backend/src/ai-engine/openrouter.engine.spec.ts
+++ b/apps/backend/src/ai-engine/openrouter.engine.spec.ts
@@ -1,0 +1,54 @@
+import { of } from 'rxjs';
+import { HttpService } from '@nestjs/axios';
+import { OpenRouterEngine } from './openrouter.engine';
+
+describe('OpenRouterEngine', () => {
+  let engine: OpenRouterEngine;
+  let httpService: { get: jest.Mock; post: jest.Mock };
+
+  beforeEach(() => {
+    httpService = { get: jest.fn(), post: jest.fn() } as any;
+    engine = new OpenRouterEngine(httpService as unknown as HttpService);
+  });
+
+  it('retrieves model list', async () => {
+    const apiKey = 'test-key';
+    const mockResponse = { data: { data: [{ id: 'model-1' }] } };
+    httpService.get.mockReturnValue(of(mockResponse));
+
+    const result = await engine.listModels(apiKey);
+
+    expect(result).toEqual([{ id: 'model-1' }]);
+    expect(httpService.get).toHaveBeenCalledWith(
+      'https://openrouter.ai/api/v1/models',
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+      },
+    );
+  });
+
+  it('uses provided model when sending message', async () => {
+    const apiKey = 'test-key';
+    const prompt = 'Ping';
+    const model = 'custom-model';
+    const mockResponse = { data: { choices: [{ message: { content: 'Pong' } }] } };
+    httpService.post.mockReturnValue(of(mockResponse));
+
+    const result = await engine.sendMessage({ prompt, apiKey, model });
+
+    expect(result).toEqual({ content: 'Pong' });
+    expect(httpService.post).toHaveBeenCalledWith(
+      'https://openrouter.ai/api/v1/chat/completions',
+      { model, messages: [{ role: 'user', content: prompt }] },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+      },
+    );
+  });
+});

--- a/apps/backend/src/ai-engine/openrouter.engine.ts
+++ b/apps/backend/src/ai-engine/openrouter.engine.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+import { AiApiEngine, ChatPayload, ChatResponse } from './ai-api-engine.base';
+
+export interface OpenRouterModel {
+  id: string;
+  name: string;
+  description: string;
+  pricing: { prompt: string; completion: string };
+  context_length: number;
+  architecture: { modality: string };
+  top_provider: { id: string; is_moderated: boolean };
+}
+
+@Injectable()
+export class OpenRouterEngine extends AiApiEngine {
+  public readonly provider = 'openrouter';
+  private readonly apiUrl = 'https://openrouter.ai/api/v1/chat/completions';
+  private readonly modelsUrl = 'https://openrouter.ai/api/v1/models';
+  private readonly defaultModel = 'openai/gpt-4o-mini';
+
+  public constructor(private readonly httpService: HttpService) {
+    super();
+  }
+
+  public async listModels(apiKey: string): Promise<OpenRouterModel[]> {
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    };
+    try {
+      const response = await firstValueFrom(
+        this.httpService.get(this.modelsUrl, { headers }),
+      );
+      return response.data?.data ?? [];
+    } catch (error) {
+      console.error(
+        'Fehler beim Abrufen der Modelle von OpenRouter:',
+        (error as any).response?.data || (error as any).message,
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Sends a message to the OpenRouter API and returns the response.
+   */
+  public async sendMessage(payload: ChatPayload): Promise<ChatResponse> {
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${payload.apiKey}`,
+    };
+
+    const body = {
+      model: payload.model ?? this.defaultModel,
+      messages: [{ role: 'user', content: payload.prompt }],
+    };
+
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post(this.apiUrl, body, { headers }),
+      );
+      const content = response.data.choices[0]?.message?.content;
+      if (!content) {
+        throw new Error('Keine gültige Antwort von OpenRouter erhalten.');
+      }
+      return { content };
+    } catch (error) {
+      console.error(
+        'Fehler bei der Kommunikation mit OpenRouter:',
+        (error as any).response?.data || (error as any).message,
+      );
+      return {
+        content: 'Sorry, there was an error communicating with OpenRouter.',
+      };
+    }
+  }
+}

--- a/apps/backend/src/chat.controller.ts
+++ b/apps/backend/src/chat.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Post, Body, Param } from '@nestjs/common';
+import { Controller, Post, Body, Get, Query } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { ChatPayload, ChatResponse } from './ai-engine/ai-api-engine.base';
+import { OpenRouterModel } from './ai-engine/openrouter.engine';
 
 // This class defines the shape of the data coming from the frontend.
 class ChatRequestDto implements ChatPayload {
@@ -21,5 +22,12 @@ export class ChatController {
   public sendMessage(@Body() requestDto: ChatRequestDto): Promise<ChatResponse> {
     const { provider, ...payload } = requestDto;
     return this.chatService.handleMessage(provider, payload);
+  }
+
+  @Get('openrouter/models')
+  public listOpenRouterModels(
+    @Query('apiKey') apiKey: string,
+  ): Promise<OpenRouterModel[]> {
+    return this.chatService.listOpenRouterModels(apiKey);
   }
 }

--- a/apps/backend/src/chat.controller.ts
+++ b/apps/backend/src/chat.controller.ts
@@ -7,6 +7,7 @@ class ChatRequestDto implements ChatPayload {
   public provider: string;
   public prompt: string;
   public apiKey?: string;
+  public model?: string;
 }
 
 @Controller('api/chat')

--- a/apps/backend/src/chat.module.ts
+++ b/apps/backend/src/chat.module.ts
@@ -10,6 +10,7 @@ import { GeminiEngine } from './ai-engine/gemini.engine';
 import { PerplexityEngine } from './ai-engine/perplexity.engine';
 import { GrokEngine } from './ai-engine/grok.engine';
 import { DeepseekEngine } from './ai-engine/deepseek.engine';
+import { OpenRouterEngine } from './ai-engine/openrouter.engine';
 import { EngineRegistryService } from './ai-engine/engine-registry.service';
 import { AI_ENGINES } from './ai-engine/ai-engine.constants';
 import { AiApiEngine } from './ai-engine/ai-api-engine.base';
@@ -29,6 +30,7 @@ import { AiApiEngine } from './ai-engine/ai-api-engine.base';
     PerplexityEngine,
     GrokEngine,
     DeepseekEngine,
+    OpenRouterEngine,
     {
       provide: AI_ENGINES,
       useFactory: (
@@ -40,6 +42,7 @@ import { AiApiEngine } from './ai-engine/ai-api-engine.base';
         perplexity: PerplexityEngine,
         grok: GrokEngine,
         deepseek: DeepseekEngine,
+        openrouter: OpenRouterEngine,
       ): AiApiEngine[] => [
         dummy,
         openAi,
@@ -49,6 +52,7 @@ import { AiApiEngine } from './ai-engine/ai-api-engine.base';
         perplexity,
         grok,
         deepseek,
+        openrouter,
       ],
       inject: [
         DummyEngine,
@@ -59,6 +63,7 @@ import { AiApiEngine } from './ai-engine/ai-api-engine.base';
         PerplexityEngine,
         GrokEngine,
         DeepseekEngine,
+        OpenRouterEngine,
       ],
     },
   ],

--- a/apps/backend/src/chat.service.ts
+++ b/apps/backend/src/chat.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { ChatPayload, ChatResponse } from './ai-engine/ai-api-engine.base';
 import { EngineRegistryService } from './ai-engine/engine-registry.service';
+import { OpenRouterEngine, OpenRouterModel } from './ai-engine/openrouter.engine';
 
 @Injectable()
 export class ChatService {
@@ -22,5 +23,13 @@ export class ChatService {
 
   public getProviders(): string[] {
     return this.registry.getProviders();
+  }
+
+  public async listOpenRouterModels(apiKey: string): Promise<OpenRouterModel[]> {
+    const engine = this.registry.get('openrouter') as OpenRouterEngine | undefined;
+    if (!engine) {
+      throw new NotFoundException(`Provider 'openrouter' wird nicht unterstützt.`);
+    }
+    return engine.listModels(apiKey);
   }
 }

--- a/apps/frontend/src/app/core/components/chat/chat.component.html
+++ b/apps/frontend/src/app/core/components/chat/chat.component.html
@@ -21,7 +21,17 @@
       <option value="perplexity">Perplexity</option>
       <option value="grok">Grok</option>
       <option value="deepseek">Deepseek</option>
+      <option value="openrouter">OpenRouter</option>
     </select>
+
+    <ng-container *ngIf="chatForm.get('provider')?.value === 'openrouter'">
+      <select formControlName="openRouterProvider" class="p-2 border rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <option *ngFor="let p of openRouterProviders" [value]="p">{{ p }}</option>
+      </select>
+      <select formControlName="model" class="p-2 border rounded-md bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        <option *ngFor="let m of filteredOpenRouterModels" [value]="m.id">{{ m.name }}</option>
+      </select>
+    </ng-container>
 
     <input formControlName="apiKey" *ngIf="requiresApiKey(chatForm.get('provider')?.value)" type="password" placeholder="API Key..." class="p-2 border rounded-md flex-shrink w-1/4 focus:outline-none focus:ring-2 focus:ring-blue-500">
 

--- a/apps/frontend/src/app/core/components/settings/settings.component.html
+++ b/apps/frontend/src/app/core/components/settings/settings.component.html
@@ -7,6 +7,17 @@
       </label>
       <input id="openai-key" formControlName="openAiApiKey" type="password" class="mt-1 block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
     </div>
+    <div>
+      <label for="openrouter-key" class="block text-sm font-medium text-gray-700">
+        OpenRouter API Key
+      </label>
+      <input
+        id="openrouter-key"
+        formControlName="openRouterApiKey"
+        type="password"
+        class="mt-1 block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+      />
+    </div>
     <div class="flex justify-end">
       <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700">
         Save Settings

--- a/apps/frontend/src/app/core/components/settings/settings.component.ts
+++ b/apps/frontend/src/app/core/components/settings/settings.component.ts
@@ -19,6 +19,7 @@ export class SettingsComponent implements OnInit {
   ) {
     this.settingsForm = this.fb.group({
       openAiApiKey: [''],
+      openRouterApiKey: [''],
     });
   }
 
@@ -27,6 +28,7 @@ export class SettingsComponent implements OnInit {
     const currentSettings = this.settingsService.getSettings();
     this.settingsForm.patchValue({
       openAiApiKey: currentSettings.openAiApiKey || '',
+      openRouterApiKey: currentSettings.openRouterApiKey || '',
     });
   }
 

--- a/apps/frontend/src/app/core/services/chat.service.ts
+++ b/apps/frontend/src/app/core/services/chat.service.ts
@@ -6,10 +6,17 @@ export interface SendMessagePayload {
   provider: string;
   prompt: string;
   apiKey?: string;
+  model?: string;
 }
 
 export interface ChatApiResponse {
   content: string;
+}
+
+export interface OpenRouterModel {
+  id: string;
+  name: string;
+  top_provider: { id: string; is_moderated: boolean };
 }
 
 @Injectable({ providedIn: 'root' })
@@ -23,6 +30,12 @@ export class ChatService {
    */
   public sendMessage(payload: SendMessagePayload): Observable<ChatApiResponse> {
     return this.http.post<ChatApiResponse>(this.apiUrl, payload);
+  }
+
+  public getOpenRouterModels(apiKey: string): Observable<OpenRouterModel[]> {
+    return this.http.get<OpenRouterModel[]>(`${this.apiUrl}/openrouter/models`, {
+      params: { apiKey },
+    });
   }
 }
 

--- a/apps/frontend/src/app/core/services/settings.service.ts
+++ b/apps/frontend/src/app/core/services/settings.service.ts
@@ -3,6 +3,7 @@ import { Store } from 'tauri-plugin-store-api';
 
 export interface AppSettings {
   openAiApiKey: string | null;
+  openRouterApiKey: string | null;
   // Future settings can be added here: mistralApiKey, theme, etc.
 }
 
@@ -14,6 +15,7 @@ export const SETTINGS_STORE = new InjectionToken<Store>('SETTINGS_STORE');
 export class SettingsService {
   private settings: AppSettings = {
     openAiApiKey: null,
+    openRouterApiKey: null,
   };
 
   public constructor(@Inject(SETTINGS_STORE) private readonly store: Store) {
@@ -27,6 +29,10 @@ export class SettingsService {
     const openAiApiKey = await this.store.get<string>('openAiApiKey');
     if (openAiApiKey) {
       this.settings.openAiApiKey = openAiApiKey;
+    }
+    const openRouterApiKey = await this.store.get<string>('openRouterApiKey');
+    if (openRouterApiKey) {
+      this.settings.openRouterApiKey = openRouterApiKey;
     }
   }
 
@@ -61,9 +67,12 @@ export class SettingsService {
   /**
    * Retrieves the API key for the specified provider.
    */
-  public getApiKey(provider: 'openai' /* | 'mistral' etc. */): string | null {
+  public getApiKey(provider: string): string | null {
     if (provider === 'openai') {
       return this.settings.openAiApiKey;
+    }
+    if (provider === 'openrouter') {
+      return this.settings.openRouterApiKey;
     }
     return null;
   }


### PR DESCRIPTION
### **User description**
## Summary
- add OpenRouter engine supporting model discovery and chat completions
- extend chat payload and controller with optional model selection
- wire OpenRouter engine into chat module and add unit tests

## Testing
- `npm test --workspace=backend`


------
https://chatgpt.com/codex/tasks/task_e_68b4313bfe448333a2106fa03494c04a


___

### **Description**
- Integrated `OpenRouterEngine` to support model discovery and chat completions.
- Enhanced `ChatPayload` to allow optional model selection.
- Added unit tests for `OpenRouterEngine` covering model listing and message sending.
- Updated chat controller and module to accommodate the new engine.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai-api-engine.base.ts</strong><dd><code>Update ChatPayload to include model selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/ai-engine/ai-api-engine.base.ts
- Added optional `model` field to `ChatPayload` interface.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/54/files#diff-4a1356a275dcccdc86b1e6b3aa7df49e714a4a5ff1451212419e8fef2d22927f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>openrouter.engine.ts</strong><dd><code>Implement OpenRouter API engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/ai-engine/openrouter.engine.ts
<li>Implemented <code>OpenRouterEngine</code> for OpenRouter API.<br> <li> Added methods to list models and send messages.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/54/files#diff-7b3fee53fa0266e77c42f2123cd418be13351819cbe6c9f6a43b0c4d916ab19e">+79/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.controller.ts</strong><dd><code>Update ChatRequestDto for model support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/chat.controller.ts
- Updated `ChatRequestDto` to include optional `model` field.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/54/files#diff-a7c3e8ec3e9810b261d674982f09dbe997612df7bea491773376f23a524e20bf">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.module.ts</strong><dd><code>Register OpenRouterEngine in chat module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/chat.module.ts
- Registered `OpenRouterEngine` in the chat module.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/54/files#diff-686bd69952e7c249cf163a20eeecbf83c12928e7e0e924ead55697b366125c7d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>new-engines.spec.ts</strong><dd><code>Include OpenRouterEngine in engine tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/ai-engine/new-engines.spec.ts
- Added `OpenRouterEngine` to engine tests.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/54/files#diff-bbdef172bd5f89d79dc94f87f310fafed675681acb9ab2094504595adf23c41d">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openrouter.engine.spec.ts</strong><dd><code>Unit tests for OpenRouterEngine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/ai-engine/openrouter.engine.spec.ts
<li>Added unit tests for <code>OpenRouterEngine</code>.<br> <li> Tested model listing and message sending functionalities.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/54/files#diff-c7fd672d57297e53b42470f7bc733ef7f540f487f0f27c9f7fb216413794e6c8">+54/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added OpenRouter as a new AI provider, including model listing and chat completions.
  - Chat requests now support an optional model field so you can choose a specific model.
- Tests
  - Added unit and integration tests covering OpenRouter model listing and message sending, plus inclusion in the multi-engine test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->