### PR TITLE
Add OpenRouter engine and frontend integration

### DIFF
--- a/apps/backend/src/ai-engine/new-engines.spec.ts
+++ b/apps/backend/src/ai-engine/new-engines.spec.ts
@@ -5,6 +5,7 @@ import { GeminiEngine } from './gemini.engine';
 import { PerplexityEngine } from './perplexity.engine';
 import { GrokEngine } from './grok.engine';
 import { DeepseekEngine } from './deepseek.engine';
+import { OpenRouterEngine } from './openrouter.engine';
 
 describe.each([
   {
@@ -36,6 +37,12 @@ describe.each([
     Engine: DeepseekEngine,
     url: 'https://api.deepseek.com/chat/completions',
     model: 'deepseek-chat',
+  },
+  {
+    name: 'OpenRouter',
+    Engine: OpenRouterEngine,
+    url: 'https://openrouter.ai/api/v1/chat/completions',
+    model: 'openai/gpt-4o-mini',
   },
 ])('$nameEngine', ({ name, Engine, url, model }) => {
   let engine: InstanceType<typeof Engine>;

--- a/apps/backend/src/ai-engine/openrouter.engine.ts
+++ b/apps/backend/src/ai-engine/openrouter.engine.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+import { AiApiEngine, ChatPayload, ChatResponse } from './ai-api-engine.base';
+
+@Injectable()
+export class OpenRouterEngine extends AiApiEngine {
+  public readonly provider = 'openrouter';
+  private readonly apiUrl = 'https://openrouter.ai/api/v1/chat/completions';
+
+  public constructor(private readonly httpService: HttpService) {
+    super();
+  }
+
+  /**
+   * Sends a message to the OpenRouter API and returns the response.
+   *
+   * Constructs the request headers and body, sends a POST request to the
+   * OpenRouter chat completions endpoint, and processes the response. In case of
+   * an error or invalid response, a friendly error message is returned.
+   */
+  public async sendMessage(payload: ChatPayload): Promise<ChatResponse> {
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${payload.apiKey}`,
+    };
+
+    const body = {
+      model: 'openai/gpt-4o-mini',
+      messages: [{ role: 'user', content: payload.prompt }],
+    };
+
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post(this.apiUrl, body, { headers }),
+      );
+      const content = response.data.choices[0]?.message?.content;
+      if (!content) {
+        throw new Error('Keine gültige Antwort von OpenRouter erhalten.');
+      }
+      return { content };
+    } catch (error) {
+      console.error(
+        'Fehler bei der Kommunikation mit OpenRouter:',
+        (error as any).response?.data || (error as any).message,
+      );
+      return {
+        content: 'Sorry, there was an error communicating with OpenRouter.',
+      };
+    }
+  }
+
+  /**
+   * Retrieves the list of available models from OpenRouter.
+   */
+  public async listModels(apiKey: string): Promise<any[]> {
+    const headers = { Authorization: `Bearer ${apiKey}` };
+    try {
+      const response = await firstValueFrom(
+        this.httpService.get('https://openrouter.ai/api/v1/models', { headers }),
+      );
+      return response.data?.data || [];
+    } catch (error) {
+      console.error(
+        'Fehler beim Abrufen der Modelle von OpenRouter:',
+        (error as any).response?.data || (error as any).message,
+      );
+      return [];
+    }
+  }
+}
+

--- a/apps/backend/src/chat.module.ts
+++ b/apps/backend/src/chat.module.ts
@@ -10,6 +10,7 @@ import { GeminiEngine } from './ai-engine/gemini.engine';
 import { PerplexityEngine } from './ai-engine/perplexity.engine';
 import { GrokEngine } from './ai-engine/grok.engine';
 import { DeepseekEngine } from './ai-engine/deepseek.engine';
+import { OpenRouterEngine } from './ai-engine/openrouter.engine';
 import { EngineRegistryService } from './ai-engine/engine-registry.service';
 import { AI_ENGINES } from './ai-engine/ai-engine.constants';
 import { AiApiEngine } from './ai-engine/ai-api-engine.base';
@@ -29,6 +30,7 @@ import { AiApiEngine } from './ai-engine/ai-api-engine.base';
     PerplexityEngine,
     GrokEngine,
     DeepseekEngine,
+    OpenRouterEngine,
     {
       provide: AI_ENGINES,
       useFactory: (
@@ -40,6 +42,7 @@ import { AiApiEngine } from './ai-engine/ai-api-engine.base';
         perplexity: PerplexityEngine,
         grok: GrokEngine,
         deepseek: DeepseekEngine,
+        openrouter: OpenRouterEngine,
       ): AiApiEngine[] => [
         dummy,
         openAi,
@@ -49,6 +52,7 @@ import { AiApiEngine } from './ai-engine/ai-api-engine.base';
         perplexity,
         grok,
         deepseek,
+        openrouter,
       ],
       inject: [
         DummyEngine,
@@ -59,6 +63,7 @@ import { AiApiEngine } from './ai-engine/ai-api-engine.base';
         PerplexityEngine,
         GrokEngine,
         DeepseekEngine,
+        OpenRouterEngine,
       ],
     },
   ],

--- a/apps/frontend/src/app/core/components/chat/chat.component.html
+++ b/apps/frontend/src/app/core/components/chat/chat.component.html
@@ -21,6 +21,7 @@
       <option value="perplexity">Perplexity</option>
       <option value="grok">Grok</option>
       <option value="deepseek">Deepseek</option>
+      <option value="openrouter">OpenRouter</option>
     </select>
 
     <input formControlName="apiKey" *ngIf="requiresApiKey(chatForm.get('provider')?.value)" type="password" placeholder="API Key..." class="p-2 border rounded-md flex-shrink w-1/4 focus:outline-none focus:ring-2 focus:ring-blue-500">

--- a/apps/frontend/src/app/core/components/chat/chat.component.ts
+++ b/apps/frontend/src/app/core/components/chat/chat.component.ts
@@ -29,6 +29,7 @@ export class ChatComponent implements OnInit, AfterViewChecked {
     'perplexity',
     'grok',
     'deepseek',
+    'openrouter',
   ];
 
   public constructor(

--- a/apps/frontend/src/app/core/components/settings/settings.component.html
+++ b/apps/frontend/src/app/core/components/settings/settings.component.html
@@ -7,6 +7,12 @@
       </label>
       <input id="openai-key" formControlName="openAiApiKey" type="password" class="mt-1 block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
     </div>
+    <div>
+      <label for="openrouter-key" class="block text-sm font-medium text-gray-700">
+        OpenRouter API Key
+      </label>
+      <input id="openrouter-key" formControlName="openRouterApiKey" type="password" class="mt-1 block w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
+    </div>
     <div class="flex justify-end">
       <button type="submit" class="px-4 py-2 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700">
         Save Settings

--- a/apps/frontend/src/app/core/components/settings/settings.component.ts
+++ b/apps/frontend/src/app/core/components/settings/settings.component.ts
@@ -19,6 +19,7 @@ export class SettingsComponent implements OnInit {
   ) {
     this.settingsForm = this.fb.group({
       openAiApiKey: [''],
+      openRouterApiKey: [''],
     });
   }
 
@@ -27,6 +28,7 @@ export class SettingsComponent implements OnInit {
     const currentSettings = this.settingsService.getSettings();
     this.settingsForm.patchValue({
       openAiApiKey: currentSettings.openAiApiKey || '',
+      openRouterApiKey: currentSettings.openRouterApiKey || '',
     });
   }
 

--- a/apps/frontend/src/app/core/services/settings.service.ts
+++ b/apps/frontend/src/app/core/services/settings.service.ts
@@ -3,6 +3,7 @@ import { Store } from 'tauri-plugin-store-api';
 
 export interface AppSettings {
   openAiApiKey: string | null;
+  openRouterApiKey: string | null;
   // Future settings can be added here: mistralApiKey, theme, etc.
 }
 
@@ -14,6 +15,7 @@ export const SETTINGS_STORE = new InjectionToken<Store>('SETTINGS_STORE');
 export class SettingsService {
   private settings: AppSettings = {
     openAiApiKey: null,
+    openRouterApiKey: null,
   };
 
   public constructor(@Inject(SETTINGS_STORE) private readonly store: Store) {
@@ -27,6 +29,10 @@ export class SettingsService {
     const openAiApiKey = await this.store.get<string>('openAiApiKey');
     if (openAiApiKey) {
       this.settings.openAiApiKey = openAiApiKey;
+    }
+    const openRouterApiKey = await this.store.get<string>('openRouterApiKey');
+    if (openRouterApiKey) {
+      this.settings.openRouterApiKey = openRouterApiKey;
     }
   }
 
@@ -61,9 +67,14 @@ export class SettingsService {
   /**
    * Retrieves the API key for the specified provider.
    */
-  public getApiKey(provider: 'openai' /* | 'mistral' etc. */): string | null {
+  public getApiKey(
+    provider: 'openai' | 'openrouter' /* | 'mistral' etc. */,
+  ): string | null {
     if (provider === 'openai') {
       return this.settings.openAiApiKey;
+    }
+    if (provider === 'openrouter') {
+      return this.settings.openRouterApiKey;
     }
     return null;
   }


### PR DESCRIPTION
### **User description**
## Summary
- add OpenRouter engine with model listing and chat completion support
- register OpenRouter provider and extend tests
- allow frontend to select OpenRouter and store its API key

## Testing
- `npm test --workspace=backend`


------
https://chatgpt.com/codex/tasks/task_e_68b4313bfe448333a2106fa03494c04a


___

### **Description**
- Added integration for `OpenRouter` engine with support for chat completions.
- Implemented API key management for `OpenRouter` in frontend settings.
- Extended chat component to allow selection of `OpenRouter` as a provider.
- Added tests for the new `OpenRouterEngine`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openrouter.engine.ts</strong><dd><code>Add OpenRouter API Integration Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/ai-engine/openrouter.engine.ts
<li>Implemented <code>OpenRouterEngine</code> for chat completions.<br> <li> Added methods to send messages and list available models.<br> <li> Included error handling for API communication.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/57/files#diff-7b3fee53fa0266e77c42f2123cd418be13351819cbe6c9f6a43b0c4d916ab19e">+72/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.module.ts</strong><dd><code>Register OpenRouter Engine in Chat Module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/chat.module.ts
<li>Registered <code>OpenRouterEngine</code> in the chat module.<br> <li> Updated engine factory to include <code>OpenRouter</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/57/files#diff-686bd69952e7c249cf163a20eeecbf83c12928e7e0e924ead55697b366125c7d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.component.html</strong><dd><code>Update Chat Component for OpenRouter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/core/components/chat/chat.component.html
<li>Added <code>OpenRouter</code> option in the chat provider selection.<br> <li> Updated API key input field for <code>OpenRouter</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/57/files#diff-d967e9adb1f135cdd1fb1cbcfb12d8c3f2cc5e59f0d680e2e06b510218b08e0e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.component.ts</strong><dd><code>Extend Chat Component with OpenRouter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/core/components/chat/chat.component.ts
- Included `OpenRouter` in the list of available engines.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/57/files#diff-c332569acce84e4c30bce961d2db32465729c68a63cdcc09e2fce57bcf2a7012">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.component.html</strong><dd><code>Update Settings Component for OpenRouter API Key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/core/components/settings/settings.component.html
- Added input field for `OpenRouter` API key in settings.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/57/files#diff-cb3110ec9fd7e203a2b106b6c6ceeeccb493f858625596a0079b8d998be61686">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.component.ts</strong><dd><code>Enhance Settings Component for OpenRouter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/core/components/settings/settings.component.ts
- Integrated `OpenRouter` API key management in settings.



</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/57/files#diff-810afb47442538279b37ca7d8f5ff706e45444b917f6eb979494a49c4b455ce9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.service.ts</strong><dd><code>Modify Settings Service for OpenRouter API Key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/core/services/settings.service.ts
<li>Updated settings interface to include <code>OpenRouter</code> API key.<br> <li> Modified API key retrieval logic to support <code>OpenRouter</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/57/files#diff-fb5855f8cb51b8ad75d530fd8afea7960ff07895358cd796491f5d3fa5972c92">+12/-1</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-engines.spec.ts</strong><dd><code>Add Tests for OpenRouter Engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/ai-engine/new-engines.spec.ts
<li>Added test cases for <code>OpenRouterEngine</code>.<br> <li> Integrated <code>OpenRouter</code> into the engine registry.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/57/files#diff-bbdef172bd5f89d79dc94f87f310fafed675681acb9ab2094504595adf23c41d">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

