### PR TITLE
Bundle backend with target-specific sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.log
 node_modules/
 .idea/
+src-tauri/binaries/

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -8,23 +8,31 @@ echo "Building backend for Tauri bundle..."
 cd apps/backend
 npm run build
 
-# Create binary using pkg (we'll need to install this)
-echo "Creating backend binary..."
+# Determine target triple for naming the sidecar.
+# Tauri sets TAURI_ENV_TARGET_TRIPLE during bundling. Fall back to the host
+# triple from `rustc` when it's not provided (e.g. during local runs).
+TARGET="${TAURI_ENV_TARGET_TRIPLE}"
+if [ -z "$TARGET" ]; then
+  TARGET=$(rustc -vV | sed -n 's/^host: //p')
+fi
 
-# For now, we'll use a simple approach - copy the built backend
-mkdir -p ../../src-tauri/binaries
-cp -r dist ../../src-tauri/binaries/backend-dist
-cp package.json ../../src-tauri/binaries/
-cp -r node_modules ../../src-tauri/binaries/ 2>/dev/null || echo "Node modules will be installed in production"
+# Create binary directory in the Tauri project
+BIN_DIR="../../src-tauri/binaries"
+mkdir -p "$BIN_DIR"
 
-# Create a startup script
-cat > ../../src-tauri/binaries/backend << 'EOF'
+# Copy the compiled backend and its dependencies
+cp -r dist "$BIN_DIR/backend-dist"
+cp package.json "$BIN_DIR/"
+cp -r node_modules "$BIN_DIR/" 2>/dev/null || echo "Node modules will be installed in production"
+
+# Create a startup script that Tauri treats as a sidecar.
+cat > "$BIN_DIR/backend-$TARGET" <<'EOF'
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "$DIR"
 node backend-dist/main.js
 EOF
 
-chmod +x ../../src-tauri/binaries/backend
+chmod +x "$BIN_DIR/backend-$TARGET"
 
-echo "Backend binary prepared for bundling"
+echo "Backend binary prepared for bundling: backend-$TARGET"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../apps/frontend/dist/frontend",
     "devUrl": "http://localhost:4200",
     "beforeDevCommand": "npm run dev:frontend",
-    "beforeBuildCommand": "npm run build:frontend"
+    "beforeBuildCommand": "npm run build:frontend && bash scripts/build-backend.sh"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Summary
- ensure backend bundling script names sidecars with the current target triple and outputs to `src-tauri/binaries`
- run backend bundling script automatically before Tauri builds
- ignore generated `src-tauri/binaries` directory

## Testing
- `bash scripts/build-backend.sh`
- `npm test --workspace=apps/backend`


------
https://chatgpt.com/codex/tasks/task_e_68b47da531988333b9159b3ad80bde6d