### PR TITLE
Bundle backend with target-specific sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.log
 node_modules/
 .idea/
+src-tauri/binaries/

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -1,30 +1,49 @@
 #!/bin/bash
+set -e
 
 # Build script for bundling the backend with Tauri app
 
 echo "Building backend for Tauri bundle..."
 
-# Build the backend
-cd apps/backend
-npm run build
+# Build the backend using the workspace so local dev dependencies are resolved
+npm run --workspace=backend build
 
-# Create binary using pkg (we'll need to install this)
-echo "Creating backend binary..."
+# Determine target triple for naming the sidecar. Tauri sets
+# TAURI_ENV_TARGET_TRIPLE during bundling. Fall back to the host triple from
+# `rustc` when it's not provided (e.g. during local runs).
+TARGET="${TAURI_ENV_TARGET_TRIPLE}"
+if [ -z "$TARGET" ]; then
+  TARGET=$(rustc -vV | sed -n 's/^host: //p')
+fi
+echo "Target triple: $TARGET"
 
-# For now, we'll use a simple approach - copy the built backend
-mkdir -p ../../src-tauri/binaries
-cp -r dist ../../src-tauri/binaries/backend-dist
-cp package.json ../../src-tauri/binaries/
-cp -r node_modules ../../src-tauri/binaries/ 2>/dev/null || echo "Node modules will be installed in production"
+# Paths used throughout the script
+BIN_DIR="src-tauri/binaries"
+BACKEND_DIR="apps/backend"
+mkdir -p "$BIN_DIR"
 
-# Create a startup script
-cat > ../../src-tauri/binaries/backend << 'EOF'
+# Copy the compiled backend and its package manifest
+cp -r "$BACKEND_DIR/dist" "$BIN_DIR/backend-dist"
+cp "$BACKEND_DIR/package.json" "$BIN_DIR/"
+# Try to copy lockfile if available for reproducible installs
+cp "$BACKEND_DIR/package-lock.json" "$BIN_DIR/" 2>/dev/null || true
+
+# Install only production dependencies inside the bundle directory
+npm install --omit=dev --prefix "$BIN_DIR" >/dev/null 2>&1 || echo "Node modules will be installed in production"
+
+# Bundle the Node runtime so the sidecar works without relying on the user's PATH
+NODE_BIN="$(which node)"
+cp "$NODE_BIN" "$BIN_DIR/node-$TARGET"
+
+# Create a startup script that Tauri treats as a sidecar.
+cat > "$BIN_DIR/backend-$TARGET" <<EOF
 #!/bin/bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$DIR"
-node backend-dist/main.js
+DIR="\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "\$DIR"
+./node-$TARGET backend-dist/main.js
 EOF
 
-chmod +x ../../src-tauri/binaries/backend
+chmod +x "$BIN_DIR/backend-$TARGET"
+chmod +x "$BIN_DIR/node-$TARGET"
 
-echo "Backend binary prepared for bundling"
+echo "Backend binary prepared for bundling: backend-$TARGET"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../apps/frontend/dist/frontend",
     "devUrl": "http://localhost:4200",
     "beforeDevCommand": "npm run dev:frontend",
-    "beforeBuildCommand": "npm run build:frontend"
+    "beforeBuildCommand": "npm run build:frontend && bash scripts/build-backend.sh"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Summary
- ensure backend bundling script names sidecars with the current target triple and outputs to `src-tauri/binaries`
- run backend bundling script automatically before Tauri builds
- ignore generated `src-tauri/binaries` directory
- install backend dependencies and bundle a node runtime so the sidecar runs without relying on the user environment

## Testing
- `TAURI_ENV_TARGET_TRIPLE=aarch64-apple-darwin bash scripts/build-backend.sh`
- `npm test --workspace=apps/backend`


------
https://chatgpt.com/codex/tasks/task_e_68b47da531988333b9159b3ad80bde6d