### PR TITLE
fix: detect target triple in backend build script

### DIFF
--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -40,13 +40,14 @@ cp package.json "$BIN_DIR/"
 cp -r node_modules "$BIN_DIR/" 2>/dev/null || echo "Node modules will be installed in production"
 
 # Create a startup script with the expected tauri naming convention
-cat > "$BIN_DIR/backend-$TARGET" << 'EOF'
+# The name should match what's configured in tauri.conf.json ("binaries/backend")
+cat > "$BIN_DIR/backend" << 'EOF'
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "$DIR"
 node backend-dist/main.js
 EOF
 
-chmod +x "$BIN_DIR/backend-$TARGET"
+chmod +x "$BIN_DIR/backend"
 
-echo "Backend binary prepared for bundling ($BIN_DIR/backend-$TARGET)"
+echo "Backend binary prepared for bundling ($BIN_DIR/backend)"


### PR DESCRIPTION
### **User description**
## Summary
- ensure backend build script detects host OS/arch when Tauri target triple isn't provided

## Testing
- `bash scripts/build-backend.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b49566aa848333aa63e74b51393075


___

### **Description**
- Enhanced the backend build script to accurately detect the target triple when not provided by the Tauri environment.
- Added checks for different operating systems to ensure correct target assignment.
- Improved fallback mechanism for determining the target triple.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-backend.sh</strong><dd><code>Improve Target Triple Detection in Build Script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/build-backend.sh
<li>Enhanced detection of target triple for backend builds.<br> <li> Added OS and architecture checks for better compatibility.<br> <li> Improved fallback mechanism for target triple assignment.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/69/files#diff-3cf3d171345756a2afb14cb6dc9ba57c371589181641699aa2da07694b0e6874">+14/-1</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Build script now auto-detects OS and architecture to set the appropriate build target for Linux, macOS, and Windows, with sensible defaults.
  - Packaging flow updated to create a dedicated binary directory, include runtime assets and dependencies, and set executable permissions.
  - Startup script name decoupled from the detected target and stabilized to a consistent name; user messages updated accordingly.
  - Added clarifying comments for maintainability; no runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->