### PR TITLE
fix: infer build target for backend script

### DIFF
--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -9,7 +9,25 @@ cd apps/backend
 npm run build
 
 # Prepare paths
-TARGET="${TAURI_ENV_TARGET_TRIPLE:-$(uname -m)-unknown-linux-gnu}"
+# Determine the target triple. When TAURI_ENV_TARGET_TRIPLE is provided by
+# the Tauri CLI we use it; otherwise infer it from the host platform so that
+# the generated binary matches the current operating system.
+if [ -n "$TAURI_ENV_TARGET_TRIPLE" ]; then
+  TARGET="$TAURI_ENV_TARGET_TRIPLE"
+else
+  ARCH="$(uname -m)"
+  case "$(uname -s)" in
+    Darwin)
+      TARGET="${ARCH}-apple-darwin"
+      ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+      TARGET="${ARCH}-pc-windows-msvc"
+      ;;
+    *)
+      TARGET="${ARCH}-unknown-linux-gnu"
+      ;;
+  esac
+fi
 BIN_DIR="../../src-tauri/binaries"
 
 echo "Creating backend binary for target $TARGET..."


### PR DESCRIPTION
### **User description**
## Summary
- detect host OS to produce correct target triple when bundling backend

## Testing
- `bash -n scripts/build-backend.sh`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b49566aa848333aa63e74b51393075


___

### **Description**
- Enhanced the `scripts/build-backend.sh` to better infer the build target for the backend.
- Added logic to detect the host OS and set the target triple accordingly.
- This change improves compatibility across different operating systems.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-backend.sh</strong><dd><code>Improve target triple inference in build script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/build-backend.sh
<li>Enhanced target triple determination for backend builds.<br> <li> Added OS detection to infer the correct target based on the host <br>platform.<br> <li> Improved compatibility for different operating systems.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/70/files#diff-3cf3d171345756a2afb14cb6dc9ba57c371589181641699aa2da07694b0e6874">+19/-1</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved target detection in the backend build process to automatically select the correct platform (macOS, Windows, Linux) when no explicit target is provided, reducing build failures on non-Linux hosts.

* **Chores**
  * Simplified and standardized cross-platform build logic for more reliable developer workflows.
  * No changes to application behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->