### PR TITLE
feat: guard settings store

### DIFF
--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -1,4 +1,9 @@
-import { ApplicationConfig, importProvidersFrom, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import {
+  ApplicationConfig,
+  importProvidersFrom,
+  provideBrowserGlobalErrorListeners,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -8,6 +13,41 @@ import { SETTINGS_STORE } from './core/services/settings.service';
 
 import { routes } from './app.routes';
 
+/**
+ * Creates a settings store. When running inside a Tauri environment the
+ * `tauri-plugin-store` is used. If the plugin is unavailable (e.g. when the
+ * application is executed in a regular browser) a lightweight in-memory
+ * fallback is returned instead. This prevents the application from crashing
+ * immediately after launch when the Tauri APIs are missing.
+ */
+function createSettingsStore(): Store {
+  try {
+    // If the Tauri API is available, use the real store implementation.
+    if (typeof window !== 'undefined' && '__TAURI__' in window) {
+      return new Store('.settings.dat');
+    }
+  } catch {
+    // Fall through to the fallback store below.
+  }
+
+  // Fallback implementation using the browser's localStorage. Only the
+  // methods used by the application are implemented.
+  const fallback = {
+    async get<T>(key: string): Promise<T | null> {
+      const value = localStorage.getItem(key);
+      return value ? (JSON.parse(value) as T) : null;
+    },
+    async set<T>(key: string, value: T): Promise<void> {
+      localStorage.setItem(key, JSON.stringify(value));
+    },
+    async save(): Promise<void> {
+      // No persistence step required for localStorage.
+    },
+  } as unknown as Store;
+
+  return fallback;
+}
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
@@ -16,7 +56,7 @@ export const appConfig: ApplicationConfig = {
     importProvidersFrom(HttpClientModule, ReactiveFormsModule),
     {
       provide: SETTINGS_STORE,
-      useFactory: () => new Store('.settings.dat'),
+      useFactory: createSettingsStore,
     },
-  ]
+  ],
 };


### PR DESCRIPTION
### **User description**
## Summary
- avoid crash when Tauri store plugin unavailable by using localStorage fallback

## Testing
- `npm run build:frontend`
- `npm run --workspace=frontend test` *(fails: TS2739 in chat.service.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b49566aa848333aa63e74b51393075


___

### **Description**
- Introduced a new `createSettingsStore` function to handle settings storage.
- Prevents application crashes when Tauri APIs are not available by using localStorage as a fallback.
- Updated the application configuration to utilize the new settings store creation logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.config.ts</strong><dd><code>Enhance settings store with fallback for Tauri plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/frontend/src/app/app.config.ts
<li>Added a function to create a settings store with a fallback for Tauri.<br> <li> Implemented localStorage fallback when Tauri plugin is unavailable.<br> <li> Updated the <code>SETTINGS_STORE</code> provider to use the new function.<br>


</details>


  </td>
  <td><a href="https://github.com/scherenhaenden/Chateroo/pull/71/files#diff-1f4f9dc4ade6cb753d3932ce8928674f4e706f73c1377d5fc78ad499f5cf514f">+43/-3</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

