### PR TITLE
Ensure backend built and run for tauri dev/build

### DIFF
--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -9,7 +9,18 @@ cd apps/backend
 npm run build
 
 # Prepare paths
-TARGET="${TAURI_ENV_TARGET_TRIPLE:-$(uname -m)-unknown-linux-gnu}"
+if [ -n "$TAURI_ENV_TARGET_TRIPLE" ]; then
+  TARGET="$TAURI_ENV_TARGET_TRIPLE"
+else
+  ARCH="$(uname -m)"
+  OS="$(uname -s)"
+  case "$OS" in
+    Linux*)   TARGET="${ARCH}-unknown-linux-gnu" ;;
+    Darwin*)  TARGET="${ARCH}-apple-darwin" ;;
+    MINGW*|MSYS*|CYGWIN*) TARGET="${ARCH}-pc-windows-msvc" ;;
+    *)        TARGET="${ARCH}-unknown-linux-gnu" ;;
+  esac
+fi
 BIN_DIR="../../src-tauri/binaries"
 
 echo "Creating backend binary for target $TARGET..."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "frontendDist": "../apps/frontend/dist/frontend",
     "devUrl": "http://localhost:4200",
-    "beforeDevCommand": "npm run dev:frontend",
-    "beforeBuildCommand": "npm run build:frontend"
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build:all"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Summary
- Run frontend and backend together during `tauri dev` and `build`
- Detect the correct OS target triple when packaging the backend sidecar

## Testing
- `npm run build:backend` *(fails: sh: 1: nest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b49566aa848333aa63e74b51393075